### PR TITLE
Fixed the squiggle image css

### DIFF
--- a/src/views/Landing/Landing.module.scss
+++ b/src/views/Landing/Landing.module.scss
@@ -72,7 +72,7 @@ div.racoonSection {
     span.anywhereText {
       position: relative;
 
-      & > picture {
+      & > img {
         position: absolute;
         bottom: -12px;
         width: 110%;


### PR DESCRIPTION
The squiggle on chingu.io was misaligned because of wrong target in CSS.
Fixed by changing it to target `img`