### PR TITLE
Fixed safari not knowing what to do with webp

### DIFF
--- a/src/components/ExampleProject/ExampleProject.jsx
+++ b/src/components/ExampleProject/ExampleProject.jsx
@@ -7,7 +7,7 @@ export default function ExampleProject(props) {
 
   let sources = [];
   for (let i = 0; i < imgs.length; i++) {
-    sources.push(<source key={i} srcSet={imgs[i]} />);
+    sources.push(<source key={i} srcSet={imgs[i][0]} type={imgs[i][1]} />);
   }
 
   return (

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom';
 import { Wrapper } from '../Wrapper';
 import { Button } from '../Button';
 import { container, header, logo, links, offset } from './Header.module.scss';
-import Logo from './Logo.webp';
+import LogoWebp from './Logo.webp';
+import Logo from './Logo.png';
 
 export default function Header() {
   // const { isAuthenticated } = useAuth0();
@@ -14,7 +15,11 @@ export default function Header() {
       <Wrapper className={container} contentAttributes={{ className: header }}>
         <div className={logo}>
           <Link to="/">
-            <img src={Logo} alt="Chingu logo" />
+            <picture>
+              <source srcSet={LogoWebp} type="image/webp" />
+              <source srcSet={Logo} type="image/png" />
+              <img src={Logo} alt="Chingu logo" />
+            </picture>
             <span>Chingu</span>
           </Link>
         </div>

--- a/src/components/LandingViewFeatureCard/LandingViewFeatureCard.jsx
+++ b/src/components/LandingViewFeatureCard/LandingViewFeatureCard.jsx
@@ -11,7 +11,7 @@ export default function LandingViewFeatureCard({
 }) {
   let sources = [];
   for (let i = 0; i < imgs.length; i++) {
-    sources.push(<source key={i} srcSet={imgs[i]} />);
+    sources.push(<source key={i} srcSet={imgs[i][0]} type={imgs[i][1]} />);
   }
 
   return (

--- a/src/views/Landing/Landing.jsx
+++ b/src/views/Landing/Landing.jsx
@@ -83,21 +83,30 @@ export default function Landing() {
         </Paragraph>
         <div className={styles.featureCards}>
           <LandingViewFeatureCard
-            imgs={[ThreeAnimalsTogetherWebp, ThreeAnimalsTogether]}
+            imgs={[
+              [ThreeAnimalsTogetherWebp, 'image/webp'],
+              [ThreeAnimalsTogether, 'image/png']
+            ]}
             imgAlt="A goat, a duck, and a dog coding together"
             imgStyle={{ position: 'relative', left: -6 }}
             title="Gain experience in a remote team"
             body="61% of full-time entry-level jobs now ask for 3 years or more of experience."
           />
           <LandingViewFeatureCard
-            imgs={[RacoonYesPleaseWebp, RacoonYesPlease]}
+            imgs={[
+              [RacoonYesPleaseWebp, 'image/webp'],
+              [RacoonYesPlease, 'image/png']
+            ]}
             imgAlt="Racoon holding up sign that says 'Yes, please'"
             title="Work on real projects"
             body="Sick of doing tutorial after tutorial with nothing to show for
             them?"
           />
           <LandingViewFeatureCard
-            imgs={[TwoAnimalsTogetherWebp, TwoAnimalsTogether]}
+            imgs={[
+              [TwoAnimalsTogetherWebp, 'image/webp'],
+              [TwoAnimalsTogether, 'image/png']
+            ]}
             imgAlt="A cat and a dog hugging each other"
             title="Join a supportive community"
             body="It can be hard to find someone to help you get unstuck."
@@ -154,7 +163,10 @@ export default function Landing() {
         </Paragraph>
         <div className={styles.projectExamples}>
           <ExampleProject
-            imgs={[JobbaticalProjectWebp, JobbaticalProject]}
+            imgs={[
+              [JobbaticalProjectWebp, 'image/webp'],
+              [JobbaticalProject, 'image/png']
+            ]}
             imgAlt="Jobbatical job listings project"
             title="Jobbatical Landing Page"
             description="A job listings and job application app for working abroad."
@@ -162,7 +174,10 @@ export default function Landing() {
             tech="HTML, CSS, Flexbox, Javascript"
           />
           <ExampleProject
-            imgs={[BudgetBoardProjectWebp, BudgetBoardProject]}
+            imgs={[
+              [BudgetBoardProjectWebp, 'image/webp'],
+              [BudgetBoardProject, 'image/png']
+            ]}
             imgAlt="BudgetBoard Chrome extension project"
             title="BudgetBoard Chrome Extension"
             description="A finance app to add income & expense categories with individual items with graph rendering."
@@ -170,7 +185,10 @@ export default function Landing() {
             tech="Javascript, SCSS, D3.js, Chrome Storage Sync"
           />
           <ExampleProject
-            imgs={[VolunteerAppProjectWebp, VolunteerAppProject]}
+            imgs={[
+              [VolunteerAppProjectWebp, 'image/webp'],
+              [VolunteerAppProject, 'image/png']
+            ]}
             imgAlt="Volunteer manager project"
             title="Volunteer Manager App"
             description="Helps people to recruit and manage volunteers for a non-profit project."


### PR DESCRIPTION
Safari doesn't identify image type from its extension. This causes it to fail as it never fallbacks to png, trying to force webp.

Added the types explicitly so Safari doesn't cause problem.